### PR TITLE
Change Dependabot schedule intervals to weekly and monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,16 +4,16 @@ updates:
   - package-ecosystem: "gradle" # or "maven" if using pom.xml
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
 
   # For your Docker / Docker Compose files
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "monthly"
 
   # For GitHub Actions workflows
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"


### PR DESCRIPTION
gradleをweeklyに、docker, github-actionsをmonthlyに変更

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * 依存関係の自動更新スケジュールを調整しました。Gradleは週次、DockerおよびGitHub Actionsは月次の更新確認となります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->